### PR TITLE
Support MPS (or CPU) as well as CUDA

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,22 @@ conda create -n samapi -y python=3.11
 conda activate samapi
 ```
 
-Install `cudatoolkit`.
+If you're using a computer with CUDA-compatible GPU, install `cudatoolkit`.
 
 ```bash
 conda install -y cudatoolkit=11.3
-```
-
-Install `samapi` and its dependencies.
-
-```bash
-python -m pip install git+https://github.com/ksugar/samapi.git
 ```
 
 If you are using WSL2, `LD_LIBRARY_PATH` will need to be updated as follows.
 
 ```bash
 export LD_LIBRARY_PATH=/usr/lib/wsl/lib:$LD_LIBRARY_PATH
+```
+
+Install `samapi` and its dependencies.
+
+```bash
+python -m pip install git+https://github.com/ksugar/samapi.git
 ```
 
 ## Usage


### PR DESCRIPTION
This looks great!

I wanted to test it, but I use a Mac and so don't have CUDA.

Not sure if it's the best way to do it, but in case CUDA isn't available this PR tries to switch to use the [MPS backend](https://pytorch.org/docs/stable/notes/mps.html) if possible, or CPU as a last resort.

That change was enough for me to get https://github.com/ksugar/qupath-extension-sam working on my Mac.