### PR TITLE
Support points and multi-mask output

### DIFF
--- a/src/samapi/main.py
+++ b/src/samapi/main.py
@@ -77,8 +77,8 @@ def get_sam_model(model_type: ModelType):
 
 
 device = _get_device()
-predictor = SamPredictor(get_sam_model(ModelType.vit_h).to(device=device))
 sam_type = ModelType.vit_h
+predictor = SamPredictor(get_sam_model(sam_type).to(device=device))
 last_image = None
 
 
@@ -108,8 +108,6 @@ async def predict_sam(body: SAMBody):
     else:
         print('Keeping the previous image!')
 
-    print(f'Coords: {_parse_point_coords(body).shape if body.point_coords else None}')
-    print(f'Labels: {_parse_point_labels(body).shape if body.point_labels else None}')
     import time
     start_time = time.time_ns()
     masks, quality, _ = predictor.predict(


### PR DESCRIPTION
Suggestions to incorporate more of SAM's features.

Useful with the proposed changes to the QuPath extension: https://github.com/ksugar/qupath-extension-sam/pull/3

I tried not to break anything along the way, but don't know for sure if I succeeded...

The PR also stores the last image, and checks if it is unchanged to avoid resetting it within the predictor. This can make prediction *much* faster and more responsive when used from the proposed QuPath extension.

> Related to that, I'm not familiar enough with all this to know if the use of globals could cause trouble if multiple users are depending on the same server... so I just followed the existing pattern.