### PR TITLE
Update ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10"]
         poetry-version: [1.5.1]
     name: ${{ matrix.os }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9, 3.10, 3.11]
+        python-version: [3.9, 3.10]
         poetry-version: [1.5.1]
     runs-on: ${{ matrix.os }}
     if: github.event_name == 'release' && github.event.action == 'published'


### PR DESCRIPTION
This PR removes `Python 3.11` from the CI process as the [v0.3.1](https://github.com/ksugar/samapi/releases/tag/v0.3.1) does not support `Python 3.11`.